### PR TITLE
Create face detection notebook

### DIFF
--- a/opencv_faces.ipynb
+++ b/opencv_faces.ipynb
@@ -1,0 +1,578 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "df89f473-caf3-4850-bcf2-e371a0cc64d8",
+   "metadata": {},
+   "source": [
+    "# Face Detection and Recognition\n",
+    "This notebook provides a quick resource for exploring OpenCV's built-in face detection and recognition algorithms, based on the third section of the following youtube video: https://www.youtube.com/watch?v=oXlwWbU8l2o\n",
+    "\n",
+    "Images of 'famous' people are used as examples, which were downloaded from the Labelled Faces in the Wild (LFW) dataset, available as part of the following Kaggle competition: https://www.kaggle.com/jessicali9530/lfw-dataset\n",
+    "\n",
+    "The goal of Face Detection is to identify a rectangular bounding box around each face in an input image. Additional features may be detected as well, e.g. eyes, smile, etc. The goal of Face Recognition is to correctly identify the person based on their facial features. Common practice is to first apply face detection, then apply a facial recognition algorithm to identify the name of the person from features in the detected face image.\n",
+    "\n",
+    "## References\n",
+    "- https://github.com/Kaggle/kaggle-api (you can use the api to download the data)\n",
+    "- https://pythonprogramming.net/haar-cascade-object-detection-python-opencv-tutorial/\n",
+    "- https://towardsdatascience.com/a-dog-detector-and-breed-classifier-4feb99e1f852 (also see https://github.com/HenryDashwood/dog_breed_classifier)\n",
+    "- https://keras.io/guides/transfer_learning/\n",
+    "- https://towardsdatascience.com/face-detection-in-2-minutes-using-opencv-python-90f89d7c0f81\n",
+    "- https://www.pyimagesearch.com/2014/07/21/detecting-circles-images-using-opencv-hough-circles/\n",
+    "- "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "08811096-1863-435b-8278-ae2a74f65167",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2 as cv\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5777731f-42d8-4167-bc2c-c3c3774d2a0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir_root = r\"/home/fdpearce/Documents/Projects/data/Images/LFW/lfw-deepfunneled/lfw-deepfunneled\"\n",
+    "# Name must match folder name exactly after a single modification: spaces, \" \", are converted to underscores, \"_\"\n",
+    "people = [\"Bill Clinton\"]\n",
+    "#people = [\"George W Bush\", \"Laura Bush\", \"Vladimir Putin\", \"Gloria Macapagal Arroyo\", \"Arnold Schwarzenegger\", \"Bill Clinton\", \\\n",
+    "#          \"Hugo Chavez\", \"Serena Williams\", \"Colin Powell\", \"Junichiro Koizumi\", \"Jennifer Capriati\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5ecddecb-ec35-4ee5-842e-8e00d8fb1df7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# of People with Images Available = 5749\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = [i for i in os.listdir(dir_root)]\n",
+    "print(f\"# of People with Images Available = {len(p)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dabf2c55-feff-4cba-a4e9-aa9f68ad2781",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_training_data(dir_root, people, person_img_max, face_params, detect_faces=False, random_seed=0, verbose=False):\n",
+    "    \"\"\"Create training data from the following inputs:\n",
+    "    dir_root = a string containing base directory with subfolders containing images for each person\n",
+    "    people = a list containing string values, with each string containing a person's name. These are the folder names, EXCEPT for spaces instead of underscores\n",
+    "    person_img_max = an integer specifying the maximum number of training images to return for each person. Set this to a value larger than that maximum # of images available if you want to process all images\n",
+    "    face_params = a dictionary containing the parameters to pass to the detectMultiScale method of the haar cascade class, e.g. scaleFactor, minNeighbors\n",
+    "    detect_faces = a boolean-like value (True/False, 1/0, etc) that turns on/off face detection. Turn this off as a dry run to check how much image data will be processed\n",
+    "    random_seed = an integer that determines the order of the random shuffle applied to images before selecting the training samples\n",
+    "    verbose = a boolean-like value that, when truthy, prints additional details during execution for validation/debugging purposes\n",
+    "    \"\"\"\n",
+    "    random.seed(random_seed)\n",
+    "    features = []\n",
+    "    labels = []\n",
+    "    for person in people:\n",
+    "        img_num = 0\n",
+    "        total_faces = 0\n",
+    "        label = people.index(person)\n",
+    "        path = os.path.join(dir_root, \"_\".join(person.split(\" \")))\n",
+    "        img_files = os.listdir(path)\n",
+    "        random.shuffle(img_files)\n",
+    "        for img in img_files[:min(person_img_max, len(img_files))]:\n",
+    "            img_path = os.path.join(path, img)\n",
+    "            img_num += 1\n",
+    "            print(f\"Working on Image # {img_num}: {img}\")\n",
+    "            if detect_faces:\n",
+    "                face_feature, face_label = detect_img_faces(img_path, label, verbose=verbose, **face_params)\n",
+    "                if face_label >= 0:\n",
+    "                    total_faces += 1\n",
+    "                    features.append(face_feature)\n",
+    "                    labels.append(face_label)\n",
+    "        print(f\"{img_num} training images with {total_faces} faces identified for {person}\")\n",
+    "    return features, labels\n",
+    "\n",
+    "def detect_primary_face(gray, haar_class_face, verbose=False, max_iter=10, **face_params):\n",
+    "    \"\"\"Identify the \"primary\", or most robust, face detected within the input grayscale image, gray.\n",
+    "    \"\"\"\n",
+    "    num_iter = 0\n",
+    "    face_detected = haar_class_face.detectMultiScale(gray, **face_params)\n",
+    "    num_faces = len(face_detected)\n",
+    "    if verbose:\n",
+    "        print(f\"Initial # of Faces = {num_faces}\")\n",
+    "    while num_faces != 1 and num_iter != max_iter:\n",
+    "        num_iter += 1\n",
+    "        if verbose:\n",
+    "            print(f\"Iteration # = {num_iter}\")\n",
+    "        # Update minNeighbors value in copy of params dict\n",
+    "        if num_iter == 1:\n",
+    "            face_params_new = face_params.copy()\n",
+    "        if num_faces == 0 and face_params_new['minNeighbors'] > 1:\n",
+    "            face_params_new['minNeighbors'] -= 1\n",
+    "        elif num_faces > 1:\n",
+    "            face_params_new['minNeighbors'] += 2\n",
+    "        else:\n",
+    "            print(\"Unable to recognize face in input image\")\n",
+    "            print(f\"Verify that either 1) num_faces is zero ({num_faces==0}) and minNeighbors is one ({face_params_new['minNeighbors']==1})\")\n",
+    "            print(f\"OR 2) the maximum # of iterations has been reached ({num_iter==max_iter})\")\n",
+    "            print(\"If either of these scenarios occurs, consider changing the input scaleFactor and/or initial minNeighbors value. If neither 1) or 2) applies, then there is an unknown bug somewhere...\")\n",
+    "        if verbose:\n",
+    "            print(f\"minNeighbors = {face_params_new['minNeighbors']}\")\n",
+    "        face_detected = haar_class_face.detectMultiScale(gray, **face_params_new)\n",
+    "        num_faces = len(face_detected)\n",
+    "    return face_detected\n",
+    "\n",
+    "def detect_img_faces(img_path, label, verbose=False, **face_params):\n",
+    "    # Create face detector instance\n",
+    "    # face_params['flags'] = cv.CASCADE_SCALE_IMAGE\n",
+    "    haar_face = \"haar_cascade_frontalface.xml\" # Path to haar cascade xml file\n",
+    "    haar_class_face = cv.CascadeClassifier(haar_face)\n",
+    "    # Load image and convert to grayscale\n",
+    "    img_array = cv.imread(img_path)\n",
+    "    gray = cv.cvtColor(img_array, cv.COLOR_BGR2GRAY)\n",
+    "    # Detect faces, then store face image as feature and person's name id as label\n",
+    "    #faces_rect = haar_class_face.detectMultiScale(gray, **face_params)\n",
+    "    face_rect = detect_primary_face(gray, haar_class_face, verbose=verbose, **face_params)\n",
+    "    # detected_primary_face returns a list that should only have one face_rect value\n",
+    "    # This is strictly enforced below. Any other face_rect error should be captured by the exception\n",
+    "    # e.g. if face_rect is empty\n",
+    "    try:\n",
+    "        (x, y, w, h) = face_rect[0]\n",
+    "    except Exception as e:\n",
+    "        print(f\"The following error occurred when performing face detection for the image at {img_path}:\")\n",
+    "        print(e)\n",
+    "        x = None\n",
+    "    if verbose:\n",
+    "        print(*face_rect[0], sep=\", \")\n",
+    "    if x:\n",
+    "        face_roi = gray[y:y+h, x:x+w]\n",
+    "        face_label = label\n",
+    "    else:\n",
+    "        face_roi = None\n",
+    "        face_label = -1\n",
+    "    return face_roi, face_label\n",
+    "\n",
+    "def show_frame(frame, frame_title):\n",
+    "    cv.imshow(frame_title, frame)\n",
+    "    cv.waitKey(0)\n",
+    "    cv.destroyAllWindows()\n",
+    "    \n",
+    "def draw_show_detected_objects(detected_frame, detected_rect, frame_to_show=None, print_detected=False, rect_color=(255, 255, 255), rect_thickness=2):\n",
+    "    \"\"\"Print detected object(s) on source image\"\"\"\n",
+    "    for i, (x, y, w, h) in enumerate(detected_rect):\n",
+    "        if print_detected:\n",
+    "            print(f\"Object {i} Location: x={x}, y={y}, w={w}, h={h}\")\n",
+    "        detected_frame = cv.rectangle(detected_frame, (x, y), (x+w, y+h), rect_color, thickness=rect_thickness)\n",
+    "        if isinstance(frame_to_show, np.ndarray):\n",
+    "            show_frame(frame_to_show[y:y+h, x:x+w], \"Objects Detected in Image\")\n",
+    "    return detected_frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4620061-61e9-4f26-bbfe-43758cf660fa",
+   "metadata": {},
+   "source": [
+    "### Load an Example Image and Convert to Grayscale"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "11c047bf-d25f-45b4-b98f-78a59e198cea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person = people[0]\n",
+    "img_num = \"0017\"\n",
+    "img_ext = \".jpg\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6bdb0360-24ea-414c-b18b-1fb651786693",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "per_fname = \"_\".join(person.split(\" \"))\n",
+    "img_path = os.path.join(dir_root, per_fname, \"_\".join([per_fname, img_num])+img_ext)\n",
+    "img_face = cv.imread(img_path)\n",
+    "gray_face = cv.cvtColor(img_face, cv.COLOR_BGR2GRAY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8a657b4-3001-4e6a-b14c-10bb2fe365cb",
+   "metadata": {},
+   "source": [
+    "## Face Detection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03584fff-2ebe-4b0f-bbfb-d74f5521d9ab",
+   "metadata": {},
+   "source": [
+    "The first step is to download Haar Cascades xml file for frontal face detection from the following link:\n",
+    "\n",
+    "https://github.com/opencv/opencv/blob/master/data/haarcascades/haarcascade_frontalface_default.xml\n",
+    "\n",
+    "If you want to follow the code below, then you should also download the eye and smile detection xml files from the haarcascades folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7a78e042-92c2-4b43-8f5e-bbdb3a7ce38d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# scaleFactor = 1.1, minNeighbors = 5 or 10 finds face\n",
+    "# scaleFactor = 1.1, minNeighbors = 5 both eyes and button, or 10 finds right eye and button\n",
+    "# scaleFactor = 1.1, minNeighbors = 100 needed to get the right face w/ no false positives\n",
+    "haar_image = gray_face.copy()\n",
+    "haar_face = 'haar_cascade_frontalface.xml'\n",
+    "haar_eye = 'haar_cascade_eye.xml'\n",
+    "haar_smile = 'haar_cascade_smile.xml'\n",
+    "haar_scaleFactor = 1.2\n",
+    "haar_minNeighbors = 10\n",
+    "haar_minSize = (20, 20)\n",
+    "haar_flags = cv.CASCADE_SCALE_IMAGE\n",
+    "haar_class_face = cv.CascadeClassifier(haar_face)\n",
+    "haar_class_smile = cv.CascadeClassifier(haar_smile)\n",
+    "haar_class_eye = cv.CascadeClassifier(haar_eye)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e87bd89a-1d8d-43b5-ae65-894f28321f6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detect_face_rect = haar_class_face.detectMultiScale(haar_image, scaleFactor=haar_scaleFactor, minNeighbors=haar_minNeighbors, minSize=haar_minSize, flags=haar_flags)\n",
+    "detect_eye_rect = haar_class_eye.detectMultiScale(haar_image, scaleFactor=haar_scaleFactor, minNeighbors=haar_minNeighbors, minSize=haar_minSize, flags=haar_flags)\n",
+    "detect_smile_rect = haar_class_smile.detectMultiScale(haar_image, scaleFactor=haar_scaleFactor, minNeighbors=haar_minNeighbors, minSize=haar_minSize, flags=haar_flags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ceb35bfa-51d4-46d7-af90-c56b39b4370f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# of Faces Found = 1\n",
+      "# of Eyes Found = 0\n",
+      "# of Smiles Found = 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"# of Faces Found = {len(detect_face_rect)}\")\n",
+    "print(f\"# of Eyes Found = {len(detect_eye_rect)}\")\n",
+    "print(f\"# of Smiles Found = {len(detect_smile_rect)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d354692f-625d-427f-bcaf-6691f9743651",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object 0 Location: x=103, y=148, w=58, h=29\n",
+      "Object 1 Location: x=122, y=96, w=72, h=36\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print detected smile(s) coordinates, and optionally show on original image\n",
+    "haar_image = draw_show_detected_objects(haar_image, detect_smile_rect, print_detected=True, frame_to_show=None, rect_color=(255, 0, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "084e094c-e03e-4172-ae73-da04c71ef2d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print detected eye(s) coordinates, and optionally show on original image\n",
+    "haar_image = draw_show_detected_objects(haar_image, detect_eye_rect, print_detected=True, frame_to_show=None, rect_color=(0, 0, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "6d4f60c6-5f64-4780-9a6d-6349c14b44a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object 0 Location: x=69, y=66, w=118, h=118\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print detected face(s) coordinates, and optionally show on original image\n",
+    "haar_image = draw_show_detected_objects(haar_image, detect_face_rect, print_detected=True, frame_to_show=None, rect_color=(0, 0, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "45157fce-0d33-436f-9fee-841a7830be10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_frame(haar_image, f\"Faces(s) Detected in Image of {person}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4df262bd-9468-426d-8a07-ff6a3df22ce8",
+   "metadata": {},
+   "source": [
+    "## Face Recognition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e6c0e43-153e-490b-841b-767ce8887ab4",
+   "metadata": {},
+   "source": [
+    "### Load Training Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25a059c2-d9c2-497e-a298-6bd45a8de55c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person_img_max = 20\n",
+    "detect_face_params = {'scaleFactor': 1.1,\n",
+    "               'minNeighbors': 4,\n",
+    "               'minSize': (20, 20)}\n",
+    "features, labels = create_training_data(dir_root, people, person_img_max, face_params, detect_faces=True, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "021d1a4b-7dc4-44d6-970d-b4a51893a8cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"# of Features = {len(features)}\")\n",
+    "print(f\"# of Labels = {len(labels)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adad592d-227f-432f-a312-b793610f87f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visually inspect example images and the bounding box detected by the face recognition algorithm\n",
+    "# Use the verbose setting above to print out bounding boxes\n",
+    "person = people[0]\n",
+    "img_num = [\"0017\", \"0012\", \"0014\", \"0029\", \"0013\", \"0027\", \"0020\"]\n",
+    "img_ext = \".jpg\"\n",
+    "face_rectangles = [[[72, 69, 113, 113]], \\\n",
+    "              [[73, 73, 110, 110]], \\\n",
+    "              [[61, 61, 126, 126]], \\\n",
+    "              [[64, 63, 123, 123]], \\\n",
+    "              [[68, 65, 119, 119]], \\\n",
+    "              [[70, 65, 118, 118]], \\\n",
+    "              [[70, 69, 113, 113]]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f29f379-c4fe-42c2-9dc2-cb625c5d9514",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ind, im_num in enumerate(img_num):\n",
+    "    per_fname = \"_\".join(person.split(\" \"))\n",
+    "    img_path = os.path.join(dir_root, per_fname, \"_\".join([per_fname, im_num])+img_ext)\n",
+    "    img_face = cv.imread(img_path)\n",
+    "    gray_face = cv.cvtColor(img_face, cv.COLOR_BGR2GRAY)\n",
+    "    gray_face = draw_show_detected_objects(gray_face, face_rectangles[ind], print_detected=True, frame_to_show=None, rect_color=(0, 0, 0))\n",
+    "    show_frame(gray_face, f\"Primary Face Detected for {person}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1816058-18ce-4bf9-a343-5134746fa7fa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb676fb2-17db-4c08-8a8e-aa19febae28b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47a32bf7-6694-4455-9679-5e56cea19398",
+   "metadata": {},
+   "source": [
+    "### 2. Train Face Recognition Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdfa0419-ab32-46ef-83ac-ccd1f325e3ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_recognizer_data = False\n",
+    "face_recognizer = cv.face.LBPHFaceRecognizer_create()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7954fac-95cf-4d7f-8220-bead53aea7f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features = np.array(features, dtype=\"object\")\n",
+    "labels = np.array(labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a85fc96f-d9fc-4dd4-be7e-b881a835b57c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "face_recognizer.train(features, labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d8a1b1d-adb5-4d54-a99d-c2871fca2842",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if save_recognizer_data:\n",
+    "    face_recognizer.save(\"face_recognizer.yml\")\n",
+    "    np.save(\"features.npy\", features)\n",
+    "    np.save(\"labels.npy\", labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f87352c-4698-45d7-90e7-28e44866b6d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp=[[]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b26377d5-3765-4f01-afd6-ff69366e18b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(*tmp[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bae34bd-ff55-4479-836d-82f19c9c6fac",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5060112-e052-4fab-9694-c8e67cf1b4d9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ddf2481-8c27-402b-bc16-89ce02d407cb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1439d45-ce51-42e4-883f-4e83fa35e388",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains the first draft of the face detection notebook. 

I've expanded on the code from the OpenCV course in the following ways:
1. Created a function that returns the "primary" haar cascade objects detected in an image, instead of all the objects detected. 
  - Description: When applying the haar-based object detection algorithm with a given set of parameters, it is common to detect too many or too few objects compared to the number of actual objects in an image. `detect_primary_objects` handles this issue by allowing you to specify a desired number of "primary" objects you believe are in the image. It will automatically adjust the input parameter, minNeighbors, to find that number of objects. 
  - Example: Consider an example in which an input image contains only one object, a face. If we apply a haar-based facial detection algorithm and obtain three output faces, then we can consider one the "true" face, and the two others false positive faces. In this case the algorithm will increase minNeighbors to try and return the desired number of faces. If, on the other hand, the object recognition algorithm detects zero faces, even though the example image contains one face (i.e. a false negative), the algorithm will reduce minNeighbors to try to return the desired number of faces.
  - Use: This functionality is useful for obtaining clean training data when the number of objects in each image is known. For example, a set of training images where each image contains a single primary face that is the region of interest for subsequent modeling.  By providing cleaner training data, we can improve the performance of subsequent modeling tasks, such as detecting more detailed features within a face (e.g. eyes), facial recognition, etc.
2. Created a function, `show_detected_objects`, for plotting object detect results overlaid on their source image, including an option to zoom in on each detected object in a separate image.